### PR TITLE
feat: use `with_connection` where possible

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './with_connection'
+
 module ActiveRecord
   module Acts #:nodoc:
     module List #:nodoc:
@@ -459,7 +461,9 @@ module ActiveRecord
 
         # When using raw column name it must be quoted otherwise it can raise syntax errors with SQL keywords (e.g. order)
         def quoted_position_column
-          @_quoted_position_column ||= self.class.connection.quote_column_name(position_column)
+          @_quoted_position_column ||= ActiveRecord::Acts::List::WithConnection.new(self.class).call do |connection|
+            connection.quote_column_name(position_column)
+          end
         end
 
         # Used in order clauses

--- a/lib/acts_as_list/active_record/acts/sequential_updates_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/sequential_updates_method_definer.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
+require_relative './with_connection'
+
 module ActiveRecord::Acts::List::SequentialUpdatesMethodDefiner #:nodoc:
   def self.call(caller_class, column, sequential_updates_option)
     caller_class.class_eval do
       define_method :sequential_updates? do
-        if !defined?(@sequential_updates)
-          if sequential_updates_option.nil?
-            table_exists =
-              if active_record_version_is?('>= 5')
-                caller_class.connection.data_source_exists?(caller_class.table_name)
-              else
-                caller_class.connection.table_exists?(caller_class.table_name)
-              end
-            index_exists = caller_class.connection.index_exists?(caller_class.table_name, column, unique: true)
-            @sequential_updates = table_exists && index_exists
-          else
-            @sequential_updates = sequential_updates_option
-          end
-        else
-          @sequential_updates
+        return @sequential_updates if defined?(@sequential_updates)
+
+        return @sequential_updates = sequential_updates_option unless sequential_updates_option.nil?
+
+        ActiveRecord::Acts::List::WithConnection.new(caller_class).call do |connection|
+          table_exists =
+            if active_record_version_is?('>= 5')
+              connection.data_source_exists?(caller_class.table_name)
+            else
+              connection.table_exists?(caller_class.table_name)
+            end
+          index_exists = connection.index_exists?(caller_class.table_name, column, unique: true)
+          @sequential_updates = table_exists && index_exists
         end
       end
 

--- a/lib/acts_as_list/active_record/acts/with_connection.rb
+++ b/lib/acts_as_list/active_record/acts/with_connection.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Acts
+    module List
+      class WithConnection
+        def initialize(recipient)
+          @recipient = recipient
+        end
+
+        attr_reader :recipient
+
+        def call
+          if recipient.respond_to?(:with_connection)
+            recipient.with_connection do |connection|
+              yield connection
+            end
+          else
+            yield recipient.connection
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/rails/rails/pull/51349 - this allows rails 7.2 applications to raise an error or emit a deprecation warning whenever `ActiveRecord::Base.connection` is used.

this makes sure that in rails 7.1 and after we use the new, preferred method.